### PR TITLE
45ACP: fix incorrect ammo box values

### DIFF
--- a/BulletLib/45ACP.zsc
+++ b/BulletLib/45ACP.zsc
@@ -40,7 +40,7 @@ class HD45ACPAmmo : HDRoundAmmo
 {
 	override void SplitPickup()
 	{
-		SplitPickupBoxableRound(10, 70, "HD45ACPBoxPickup", "45TN", "45RN");
+		SplitPickupBoxableRound(10, 50, "HD45ACPBoxPickup", "45TN", "45RN");
 	}
 
 	const EncRoundLoaded = 0.55;


### PR DESCRIPTION
requires 70 rounds to make a box but only gives 50 back.